### PR TITLE
avoid ODR violations on uncoming gcc-10

### DIFF
--- a/gui/Linux.h
+++ b/gui/Linux.h
@@ -44,8 +44,8 @@
 
 extern gboolean UseGui;
 extern int StatesC;
-char cfgfile[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
-char cfgfile_basename[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
+extern char cfgfile[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
+extern char cfgfile_basename[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
 
 int LoadConfig();
 void SaveConfig();

--- a/gui/LnxMain.c
+++ b/gui/LnxMain.c
@@ -48,6 +48,8 @@ enum {
 };
 
 gboolean UseGui = TRUE;
+char cfgfile[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
+char cfgfile_basename[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
 
 static void CreateMemcard(char *filename, char *conf_mcd) {
 	gchar *mcd;

--- a/plugins/dfinput/pad.h
+++ b/plugins/dfinput/pad.h
@@ -151,7 +151,7 @@ typedef struct tagKeyDef {
 enum { ANALOG_XP = 0, ANALOG_XM, ANALOG_YP, ANALOG_YM };
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-SDL_GameControllerButton controllerMap[DKEY_TOTAL];	
+extern SDL_GameControllerButton controllerMap[DKEY_TOTAL];
 #endif
 
 typedef struct tagPadDef {

--- a/plugins/dfnet/cfg.c
+++ b/plugins/dfnet/cfg.c
@@ -13,6 +13,22 @@
 
 #define CFG_FILENAME "dfnet.cfg"
 
+// definitions of globals declared in "dfnet.h"
+Config conf;
+int sock;
+char *PadSendData;
+char *PadRecvData;
+char PadSendSize;
+char PadRecvSize;
+char PadSize[2];
+int PadCount;
+int PadCountMax;
+int PadInit;
+int Ping;
+volatile int WaitCancel;
+fd_set rset;
+fd_set wset;
+
 void SaveConf() {
 	FILE *f;
 

--- a/plugins/dfnet/dfnet.h
+++ b/plugins/dfnet/dfnet.h
@@ -56,7 +56,7 @@ __private_extern char* PLUGLOC(char* toloc);
 
 typedef void* HWND;
 
-struct timeval tm;
+extern struct timeval tm;
 
 #define CALLBACK
 
@@ -70,24 +70,24 @@ typedef struct {
 	char ipAddress[32];
 } Config;
 
-Config conf;
+extern Config conf;
 
 void LoadConf();
 void SaveConf();
 
-int sock;
-char *PadSendData;
-char *PadRecvData;
-char PadSendSize;
-char PadRecvSize;
-char PadSize[2];
-int PadCount;
-int PadCountMax;
-int PadInit;
-int Ping;
-volatile int WaitCancel;
-fd_set rset;
-fd_set wset;
+extern int sock;
+extern char *PadSendData;
+extern char *PadRecvData;
+extern char PadSendSize;
+extern char PadRecvSize;
+extern char PadSize[2];
+extern int PadCount;
+extern int PadCountMax;
+extern int PadInit;
+extern int Ping;
+extern volatile int WaitCancel;
+extern fd_set rset;
+extern fd_set wset;
 
 long sockInit();
 long sockShutdown();


### PR DESCRIPTION
Noticed as a build failure against fresh gcc-master:

```
...
[ 29%] Linking C executable pcsxr
ld: CMakeFiles/pcsxr.dir/Cheat.c.o:(.bss+0x20):
  multiple definition of `cfgfile_basename'; CMakeFiles/pcsxr.dir/AboutDlg.c.o:(.bss+0x0): first defined here
ld: CMakeFiles/pcsxr.dir/Cheat.c.o:(.bss+0x1020):
  multiple definition of `cfgfile'; CMakeFiles/pcsxr.dir/AboutDlg.c.o:(.bss+0x1000): first defined here
ld: CMakeFiles/pcsxr.dir/ConfDlg.c.o:(.bss+0x7f160):
  multiple definition of `cfgfile_basename'; CMakeFiles/pcsxr.dir/AboutDlg.c.o:(.bss+0x0): first defined here
ld: CMakeFiles/pcsxr.dir/ConfDlg.c.o:(.bss+0x80160):
  multiple definition of `cfgfile'; CMakeFiles/pcsxr.dir/AboutDlg.c.o:(.bss+0x1000): first defined here
...
```

The change flips header definitions to declarations.

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.