### PR TITLE
Check if toc/cue datafile part is valid

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -534,10 +534,17 @@ static int parsetoc(const char *isofile) {
 			}
 		}
 	}
-	if (numtracks > 0)
-		cdHandle = fopen(filename, "rb");
 
 	fclose(fi);
+
+	if (numtracks > 0) {
+		// Test if the data file pointed to in the toc/cue file can be opened.
+		fi = fopen(filename, "rb");
+		if (fi != NULL) {
+			fclose(cdHandle);
+			cdHandle = fi;
+		}
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Check if the file referred to in the datafile part of the toc/cue file
can be opened. The previous behaviour triggered a segmentation fault
when the file handle for the iso image was replaced by a null pointer if
the datafile path in the toc/cue file pointed to a non-existing path.