### PR TITLE
Fix compilation under GCC 10+

### DIFF
--- a/gui/Config.c
+++ b/gui/Config.c
@@ -24,6 +24,9 @@
 
 #include "Linux.h"
 
+char cfgfile_basename[MAXPATHLEN];
+char cfgfile[MAXPATHLEN];
+
 /* TODO escaping/unescaping would be nice, as would maxchars */
 static void GetValue(char *src, char *name, char *outvar) {
 	char *tmp;

--- a/gui/Linux.h
+++ b/gui/Linux.h
@@ -44,8 +44,8 @@
 
 extern gboolean UseGui;
 extern int StatesC;
-char cfgfile[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
-char cfgfile_basename[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
+extern char cfgfile[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
+extern char cfgfile_basename[MAXPATHLEN];	/* ADB Comment this out - make a local var, or at least use gchar funcs */
 
 int LoadConfig();
 void SaveConfig();

--- a/plugins/bladesio1/sio1.c
+++ b/plugins/bladesio1/sio1.c
@@ -55,8 +55,6 @@ static const unsigned char build	= 1;
 
 static void (CALLBACK *irqCallback)() = 0;
 
-Settings settings;
-
 /* sio status flags.
  */
 enum {

--- a/plugins/dfinput/pad.h
+++ b/plugins/dfinput/pad.h
@@ -151,7 +151,7 @@ typedef struct tagKeyDef {
 enum { ANALOG_XP = 0, ANALOG_XM, ANALOG_YP, ANALOG_YM };
 
 #if SDL_VERSION_ATLEAST(2,0,0)
-SDL_GameControllerButton controllerMap[DKEY_TOTAL];	
+extern SDL_GameControllerButton controllerMap[DKEY_TOTAL];
 #endif
 
 typedef struct tagPadDef {

--- a/plugins/dfnet/cfg.c
+++ b/plugins/dfnet/cfg.c
@@ -13,6 +13,8 @@
 
 #define CFG_FILENAME "dfnet.cfg"
 
+Config conf;
+
 void SaveConf() {
 	FILE *f;
 

--- a/plugins/dfnet/dfnet.h
+++ b/plugins/dfnet/dfnet.h
@@ -56,7 +56,7 @@ __private_extern char* PLUGLOC(char* toloc);
 
 typedef void* HWND;
 
-struct timeval tm;
+extern struct timeval tm;
 
 #define CALLBACK
 
@@ -70,24 +70,24 @@ typedef struct {
 	char ipAddress[32];
 } Config;
 
-Config conf;
+extern Config conf;
 
 void LoadConf();
 void SaveConf();
 
-int sock;
-char *PadSendData;
-char *PadRecvData;
-char PadSendSize;
-char PadRecvSize;
-char PadSize[2];
-int PadCount;
-int PadCountMax;
-int PadInit;
-int Ping;
-volatile int WaitCancel;
-fd_set rset;
-fd_set wset;
+extern int sock;
+extern char *PadSendData;
+extern char *PadRecvData;
+extern char PadSendSize;
+extern char PadRecvSize;
+extern char PadSize[2];
+extern int PadCount;
+extern int PadCountMax;
+extern int PadInit;
+extern int Ping;
+extern volatile int WaitCancel;
+extern fd_set rset;
+extern fd_set wset;
 
 long sockInit();
 long sockShutdown();


### PR DESCRIPTION
Fixes an error during linking. E.g.:

<details>
<summary>Error log snippet</summary>

```
cd /usr/src/git/pcsxr/_build/plugins/dfnet && /usr/bin/cmake -E cmake_link_script CMakeFiles/DFNet.dir/link.txt --verbose=1
/usr/bin/cc -fPIC -O3 -DNDEBUG -s -shared  -o libDFNet.so CMakeFiles/DFNet.dir/cfg.c.o CMakeFiles/DFNet.dir/dfnet.c.o CMakeFiles/DFNet.dir/unix.c.o
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x0): multiple definition of `wset'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x80): multiple definition of `rset'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x80): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x120): multiple definition of `conf'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x104): multiple definition of `PadSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x104): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x106): multiple definition of `PadRecvSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x106): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x107): multiple definition of `PadSendSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x107): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x110): multiple definition of `PadSendData'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x110): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x100): multiple definition of `WaitCancel'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x100): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/dfnet.c.o:(.bss+0x108): multiple definition of `PadRecvData'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x108): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x120): multiple definition of `WaitCancel'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x100): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x140): multiple definition of `conf'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x120): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x20): multiple definition of `wset'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x0): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0xa0): multiple definition of `rset'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x80): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x124): multiple definition of `PadSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x104): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x126): multiple definition of `PadRecvSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x106): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x127): multiple definition of `PadSendSize'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x107): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x128): multiple definition of `PadRecvData'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x108): first defined here
/usr/bin/ld: CMakeFiles/DFNet.dir/unix.c.o:(.bss+0x130): multiple definition of `PadSendData'; CMakeFiles/DFNet.dir/cfg.c.o:(.bss+0x110): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [plugins/dfnet/CMakeFiles/DFNet.dir/build.make:132: plugins/dfnet/libDFNet.so] Error 1
make[2]: Leaving directory '/usr/src/git/pcsxr/_build'
make[1]: *** [CMakeFiles/Makefile2:726: plugins/dfnet/CMakeFiles/DFNet.dir/all] Error 2
make[1]: Leaving directory '/usr/src/git/pcsxr/_build'
make: *** [Makefile:139: all] Error 2
make: Leaving directory '/usr/src/git/pcsxr/_build'
```

</details>

~~Reason for WIP: I still want to test this on my local machine.~~ Good to go.